### PR TITLE
Change mentions of Cognito to Okta

### DIFF
--- a/src/main/docs/guide/writingTheApp/oauth2.adoc
+++ b/src/main/docs/guide/writingTheApp/oauth2.adoc
@@ -41,7 +41,7 @@ micronaut:
 include::{sourceDir}/src/main/resources/application.yml[tag=oauth2]
 ----
 
-<1> Set `micronaut.security.authentication` as `idtoken`. The idtoken provided by Cognito when the OAuth 2.0 Authorization code flow ends will be saved in a cookie. The id token is a signed JWT. For every request, Micronaut extracts the JWT from the Cookie and validates the JWT signature with the remote Json Web Key Set exposed by Cognito. JWKS is exposed by the `jws-uri` entry of Cognito `.well-known/openid-configuration`
+<1> Set `micronaut.security.authentication` as `idtoken`. The idtoken provided by Okta when the OAuth 2.0 Authorization code flow ends will be saved in a cookie. The id token is a signed JWT. For every request, Micronaut extracts the JWT from the Cookie and validates the JWT signature with the remote Json Web Key Set exposed by Okta. JWKS is exposed by the `jws-uri` entry of Okta `.well-known/openid-configuration`
 <2> The provider identifier should match the last part of the url you entered as a redirect url `/oauth/callback/okta`
 <3> Client Secret. See previous screenshot.
 <4> Client ID. See previous screenshot.


### PR DESCRIPTION
This part of the documentation mentioned Cognito as ID provider at some places. I've changed these occurrences to Okta.